### PR TITLE
fix: screenshot and mirror with 0 bounds

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function screenshot(id, options = {}) {
 
   if (options.bounds) {
     if (typeof options.bounds !== 'object') {
-      throw new TypeError(`'bounds' must be a object`)
+      throw new TypeError(`'bounds' must be an object`)
     } else if (typeof options.bounds.x !== 'number') {
       throw new TypeError(`'bounds.x' must be a number`)
     } else if (typeof options.bounds.y !== 'number') {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function mirror(enable, firstID, secondID) {
     throw new TypeError(`'firstID' must be a number`)
   }
 
-  if (secondID && typeof secondID !== 'number') {
+  if (secondID !== undefined && typeof secondID !== 'number') {
     throw new TypeError(`'secondID' must be a number`)
   }
 

--- a/index.js
+++ b/index.js
@@ -40,14 +40,14 @@ function screenshot(id, options = {}) {
 
   if (options.bounds) {
     if (typeof options.bounds !== 'object') {
-      throw new TypeError(`'bounds' must be a number`)
-    } else if (!options.bounds.x || typeof options.bounds.x !== 'number') {
+      throw new TypeError(`'bounds' must be a object`)
+    } else if (typeof options.bounds.x !== 'number') {
       throw new TypeError(`'bounds.x' must be a number`)
-    } else if (!options.bounds.y || typeof options.bounds.y !== 'number') {
+    } else if (typeof options.bounds.y !== 'number') {
       throw new TypeError(`'bounds.y' must be a number`)
-    } else if (!options.bounds.width || typeof options.bounds.width !== 'number') {
+    } else if (typeof options.bounds.width !== 'number') {
       throw new TypeError(`'bounds.width' must be a number`)
-    } else if (!options.bounds.height || typeof options.bounds.height !== 'number') {
+    } else if (typeof options.bounds.height !== 'number') {
       throw new TypeError(`'bounds.height' must be a number`)
     }
   }

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -204,6 +204,13 @@ describe('node-mac-displays', () => {
       }).to.throw(`'bounds.height' must be a number`)
     })
 
+    it('can take screenshot if options.bounds are 0', () => {
+      const { id } = getPrimaryDisplay()
+
+      const screenshotData = screenshot(id, { bounds: { x: 0, y: 0, width: 0, height: 0 } })
+      expect(screenshotData).to.be.instanceof(Buffer)
+    })
+
     it('can write out a screenshot to the current directory', () => {
       const { id } = getPrimaryDisplay()
 

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -165,7 +165,7 @@ describe('node-mac-displays', () => {
 
       expect(() => {
         screenshot(id, { bounds: 'oh no' })
-      }).to.throw(`'bounds' must be a number`)
+      }).to.throw(`'bounds' must be an object`)
 
       expect(() => {
         screenshot(id, { bounds: { x: 'bad', y: 1, width: 10, height: 10 } })

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -184,6 +184,26 @@ describe('node-mac-displays', () => {
       }).to.throw(`'bounds.height' must be a number`)
     })
 
+    it('throws an error if one of options.bounds is undefined', () => {
+      const { id } = getPrimaryDisplay()
+
+      expect(() => {
+        screenshot(id, { bounds: { y: 1, width: 10, height: 10 } })
+      }).to.throw(`'bounds.x' must be a number`)
+
+      expect(() => {
+        screenshot(id, { bounds: { x: 1, width: 10, height: 10 } })
+      }).to.throw(`'bounds.y' must be a number`)
+
+      expect(() => {
+        screenshot(id, { bounds: { x: 1, y: 1, height: 10 } })
+      }).to.throw(`'bounds.width' must be a number`)
+
+      expect(() => {
+        screenshot(id, { bounds: { x: 1, y: 1, width: 10 } })
+      }).to.throw(`'bounds.height' must be a number`)
+    })
+
     it('can write out a screenshot to the current directory', () => {
       const { id } = getPrimaryDisplay()
 


### PR DESCRIPTION
Current code throws an exception if use `0` for `.screenshot()` bounds or for `.mirror()` secondID 